### PR TITLE
Make Prometheus blackbox exporter restart/reload with sudo privileges.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,13 @@
 ---
 - name: restart blackbox exporter
+  become: true
   systemd:
     daemon_reload: yes
     name: blackbox_exporter
     state: restarted
 
 - name: reload blackbox exporter
+  become: true
   systemd:
     name: blackbox_exporter
     state: reloaded


### PR DESCRIPTION
I'm trying to include the `cloudalchemy.blackbox-exporter` role from our own monitoring role like this:
```
- name: Deploy Blackbox Exporter
  become: yes
  include_role:
    name: cloudalchemy.blackbox-exporter
  vars:
  [...]
```
This results in a fatal error, at the point when running the handler that should restart the blackbox_exporter:
```
RUNNING HANDLER [cloudalchemy.blackbox-exporter : restart blackbox exporter] ********************************************************************************************************
fatal: [monitor]: FAILED! => {"changed": false, "msg": "failure 1 during daemon-reload: Failed to execute operation: Interactive authentication required.\n"}
```
The service could only be restarted with sudo-privileges, which in the case of an `include_role` or `import_role` won't get picked up correctly by the handler responsible for the service-restart/-reload.
This PR will make sure that the `blackbox_exporter.service` will be restarted with the correct privileges.