### PR TITLE
ansible 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ cache: pip
 services:
   - docker
 env:
-  - ANSIBLE='ansible>=2.2.0,<2.3.0'
   - ANSIBLE='ansible>=2.3.0,<2.4.0'
   - ANSIBLE='ansible>=2.4.0,<2.5.0'
+  - ANSIBLE='ansible>=2.5.0,<2.6.0'
 install:
   - pip install ${ANSIBLE} 'ansible-lint>=3.4.15' 'molecule==1.25.0' docker git-semver 'testinfra>=1.7.0,<=1.10.1'
 script:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Deploy and manage [blackbox exporter](https://github.com/prometheus/blackbox_exp
 
 ## Requirements
 
-- Ansible > 2.2
+- Ansible >= 2.3
 - go-lang installed on deployer machine (same one where ansible is installed)
 
 ## Role Variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Roman Demachkovych, Pawel Krupa
   description: Prometheus Blackbox Exporter
   license: MIT
-  min_ansible_version: 2.2
+  min_ansible_version: 2.3
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
Ansible released new "2.5" version. This PR adds support for testing role against this version.
Also this drops support for version 2.2