### PR TITLE
Retry when connecting to external services

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,12 @@
     dest: "/tmp"
     remote_src: yes
     creates: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
+  register: _download_binary
+  until: _download_binary | success
+  retries: 5
+  delay: 2
   delegate_to: localhost
+  check_mode: no
 
 - name: propagate blackbox exporter binary
   copy:
@@ -44,6 +49,10 @@
   package:
     name: "libcap2-bin"
     state: present
+  register: _download_packages
+  until: _download_packages | success
+  retries: 5
+  delay: 2
   when: ansible_os_family | lower == "debian"
 
 - name: Ensure blackbox exporter binary has cap_net_raw capability


### PR DESCRIPTION
This should prevent issues such as network timeout.

Same as in cloudalchemy/ansible-prometheus#86

Similar to: cloudalchemy/ansible-node-exporter#29