### PR TITLE
Use newer test filter schema to get rid of some deprecation warnings.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
     remote_src: yes
     creates: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
   register: _download_binary
-  until: _download_binary | success
+  until: _download_binary is success
   retries: 5
   delay: 2
   delegate_to: localhost
@@ -50,7 +50,7 @@
     name: "libcap2-bin"
     state: present
   register: _download_packages
-  until: _download_packages | success
+  until: _download_packages is success
   retries: 5
   delay: 2
   when: ansible_os_family | lower == "debian"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
     remote_src: yes
     creates: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
   register: _download_binary
-  until: _download_binary is success
+  until: _download_binary is succeeded
   retries: 5
   delay: 2
   delegate_to: localhost
@@ -50,7 +50,7 @@
     name: "libcap2-bin"
     state: present
   register: _download_packages
-  until: _download_packages is success
+  until: _download_packages is succeeded
   retries: 5
   delay: 2
   when: ansible_os_family | lower == "debian"


### PR DESCRIPTION
Use newer [test filter schema](https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#test-syntax

This will remove some deprecation warnings.