### PR TITLE
Added default module options to exporter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ blackbox_exporter_configuration_modules:
     timeout: 5s
     http:
       method: GET
-      valid_status_codes: []      
+      valid_status_codes: []
 #  http_post_2xx:
 #    prober: http
 #    timeout: 5s

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,8 @@ blackbox_exporter_configuration_modules:
     prober: http
     timeout: 5s
     http:
+      method: GET
+      valid_status_codes: []      
 #  http_post_2xx:
 #    prober: http
 #    timeout: 5s


### PR DESCRIPTION
The below addition will allow operators to deploy the black-box exporter with some sane options that will let it work out of the box.

This should fix #32 