### PR TITLE
add simple preflight checks

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,1 +1,10 @@
 ---
+- name: Assert usage of systemd as an init system
+  assert:
+    that: ansible_service_mgr == 'systemd'
+    msg: "This role only works with systemd"
+
+- name: Naive assertion of proper listen address
+  assert:
+    that:
+      - "':' in blackbox_exporter_web_listen_address"


### PR DESCRIPTION
Just basic checks ported from cloudalchemy/ansible-node-exporter.