### PR TITLE
templates/blackbox_exporter.service.j2: allow icmp probe

### DIFF
--- a/templates/blackbox_exporter.service.j2
+++ b/templates/blackbox_exporter.service.j2
@@ -33,7 +33,7 @@ RemoveIPC=true
 RestrictSUIDSGID=true
 
 {% if blackbox_exporter_systemd_version | int >= 232 %}
-PrivateUsers=true
+AmbientCapabilities=CAP_NET_RAW
 ProtectControlGroups=true
 ProtectKernelModules=true
 ProtectKernelTunables=yes


### PR DESCRIPTION
Using systemd service setup on Ubuntu 16.04 the probe icmp failed with the message:

`msg="Error listening to socket" err="listen ip4:icmp 0.0.0.0: socket: operation not permitted"`

This MR remove the **PrivateUsers** and add **AmbientCapabilities** to allow raw socket.