### PR TITLE
Add systemd block for features in 242

### DIFF
--- a/templates/blackbox_exporter.service.j2
+++ b/templates/blackbox_exporter.service.j2
@@ -30,7 +30,9 @@ MemoryDenyWriteExecute=true
 PrivateTmp=true
 ProtectHome=true
 RemoveIPC=true
+{% if blackbox_exporter_systemd_version | int >= 242 %}
 RestrictSUIDSGID=true
+{% endif %}
 
 {% if blackbox_exporter_systemd_version | int >= 232 %}
 AmbientCapabilities=CAP_NET_RAW


### PR DESCRIPTION
The systemd feature `RestrictSUIDSGID` didn't exist until 242. Add a
block around it to avoid logging noise.

```
systemd[1]: /etc/systemd/system/blackbox_exporter.service:30: Unknown lvalue 'RestrictSUIDSGID' in section 'Service'
```

[patch]