### PR TITLE
tasks/preflight.yml: fixed systemd version fact parsing

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -14,7 +14,7 @@
 
 - name: Set systemd version fact
   set_fact:
-    blackbox_exporter_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    blackbox_exporter_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"
 
 - name: Naive assertion of proper listen address
   assert:


### PR DESCRIPTION
Newer versions of systemd used by Debian 10 or Fedora 30 report its
version as three values, eg. "systemd 241 (v241-12.git1e19bcd.fc30)".
Currently preflight task assumes that it has only two and use last
one. However that value can't be converted to integer when templating
systemd service. Thats causes  icmp probe failure with the message
msg="Error listening to socket" err="listen ip4:icmp 0.0.0.0: socket:
operation not permitted".

Parsing was modified to get second value from version string