### PR TITLE
offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `blackbox_exporter_version` | 0.16.0 | Blackbox exporter package version |
+| `blackbox_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `blackbox_exporter` binary is stored on the ansible control node. | 
 | `blackbox_exporter_web_listen_address` | 0.0.0.0:9115 | Address on which blackbox exporter will be listening |
 | `blackbox_exporter_cli_flags` | {} | Additional configuration flags passed to blackbox exporter binary at startup |
 | `blackbox_exporter_configuration_modules` | http_2xx: { prober: http, timeout: 5s, http: '' } | |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `blackbox_exporter_version` | 0.16.0 | Blackbox exporter package version |
+| `blackbox_exporter_version` | 0.17.0 | Blackbox exporter package version |
 | `blackbox_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `blackbox_exporter` binary is stored on the ansible control node. | 
 | `blackbox_exporter_web_listen_address` | 0.0.0.0:9115 | Address on which blackbox exporter will be listening |
 | `blackbox_exporter_cli_flags` | {} | Additional configuration flags passed to blackbox exporter binary at startup |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 blackbox_exporter_version: 0.16.0
 
 blackbox_exporter_web_listen_address: "0.0.0.0:9115"
+blackbox_binary_local_dir: ''
 
 blackbox_exporter_cli_flags: {}
 # blackbox_exporter_cli_flags:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-blackbox_exporter_version: 0.16.0
+blackbox_exporter_version: 0.17.0
 
 blackbox_exporter_web_listen_address: "0.0.0.0:9115"
 blackbox_binary_local_dir: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 blackbox_exporter_version: 0.17.0
 
 blackbox_exporter_web_listen_address: "0.0.0.0:9115"
-blackbox_binary_local_dir: ''
+blackbox_exporter_binary_local_dir: ''
 
 blackbox_exporter_cli_flags: {}
 # blackbox_exporter_cli_flags:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,29 +13,41 @@
     group: blackbox-exp
     createhome: false
 
-- name: download blackbox exporter binary to local folder
-  become: false
-  unarchive:
-    src: "https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_exporter_version }}/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
-    remote_src: true
-    creates: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
-  register: _download_binary
-  until: _download_binary is succeeded
-  retries: 5
-  delay: 2
-  delegate_to: localhost
-  check_mode: false
+- block: 
+    - name: download blackbox exporter binary to local folder
+      become: false
+      unarchive:
+        src: "https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_exporter_version }}/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+        dest: "/tmp"
+        remote_src: true
+        creates: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
+      register: _download_binary
+      until: _download_binary is succeeded
+      retries: 5
+      delay: 2
+      delegate_to: localhost
+      check_mode: false
 
-- name: propagate blackbox exporter binary
+    - name: propagate blackbox exporter binary
+      copy:
+        src: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
+        dest: "/usr/local/bin/blackbox_exporter"
+        mode: 0750
+        owner: blackbox-exp
+        group: blackbox-exp
+      notify:
+        - restart blackbox exporter
+  when: blackbox_binary_local_dir | length == 0
+
+- name: propagate locally distributed blackbox_exporter binary
   copy:
-    src: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
+    src: "{{ blackbox_exporter_binary_local_dir }}/blackbox_exporter"
     dest: "/usr/local/bin/blackbox_exporter"
-    mode: 0750
-    owner: blackbox-exp
-    group: blackbox-exp
-  notify:
-    - restart blackbox exporter
+    mode: 0755
+    owner: root
+    group: root
+  when: blackbox_exporter_binary_local_dir | length > 0
+  notify: restart blackbox_exporter
 
 - name: Install libcap on Debian systems
   package:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,7 +13,7 @@
     group: blackbox-exp
     createhome: false
 
-- block: 
+- block:
     - name: download blackbox exporter binary to local folder
       become: false
       unarchive:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -37,7 +37,7 @@
         group: root
       notify:
         - restart blackbox exporter
-  when: blackbox_binary_local_dir | length == 0
+  when: blackbox_exporter_binary_local_dir | length == 0
 
 - name: propagate locally distributed blackbox_exporter binary
   copy:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,8 +33,8 @@
         src: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
         dest: "/usr/local/bin/blackbox_exporter"
         mode: 0750
-        owner: blackbox-exp
-        group: blackbox-exp
+        owner: root
+        group: root
       notify:
         - restart blackbox exporter
   when: blackbox_binary_local_dir | length == 0

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,7 +32,7 @@
       copy:
         src: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
         dest: "/usr/local/bin/blackbox_exporter"
-        mode: 0750
+        mode: 0755
         owner: root
         group: root
       notify:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -47,7 +47,7 @@
     owner: root
     group: root
   when: blackbox_exporter_binary_local_dir | length > 0
-  notify: restart blackbox_exporter
+  notify: restart blackbox exporter
 
 - name: Install libcap on Debian systems
   package:


### PR DESCRIPTION
- adds offline support via blackbox_exporter_binary_local_dir
- changes the filesystem permission from blackbox-exp:blackbox-exp 0750 to root:root 0755
- not tests
- touches the version 

todo: squash
fixes #68