### PR TITLE
Only run capabilities module in apply mode.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -52,3 +52,9 @@
     path: '/usr/local/bin/blackbox_exporter'
     capability: cap_net_raw+ep
     state: present
+  when: not ansible_check_mode
+
+- name: Check Debug Message
+  debug:
+    msg: "The capabilities module is skipped during check mode, as the file may not exist, causing execution to fail."
+  when: ansible_check_mode


### PR DESCRIPTION
Running this module in check mode can cause a fatal error, as the file (normally installed by the role earlier) may not exist. Also, add a debug message indicating why this was skipped.

This resolves #72. Instead of the fatal error noted there, the following output is produced and execution continues:

```
TASK [blackbox-exporter : Ensure blackbox exporter binary has cap_net_raw capability] **************************************
skipping: [hostname.mydomain.com]

TASK [blackbox-exporter : Check Debug Message] *****************************************************************************
ok: [hostname.mydomain.com] => {
    "msg": "The capabilities module is skipped during check mode, as the file may not exist, causing execution to fail."
}
```