### PR TITLE
allow using local blackbox_exporter binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `blackbox_exporter_version` | 0.18.0 | Blackbox exporter package version |
+| `blackbox_exporter_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `blackbox_exporter` binary are stored on host on which ansible is ran. This overrides `blackbox_exporter_version` parameter |
 | `blackbox_exporter_web_listen_address` | 0.0.0.0:9115 | Address on which blackbox exporter will be listening |
 | `blackbox_exporter_cli_flags` | {} | Additional configuration flags passed to blackbox exporter binary at startup |
 | `blackbox_exporter_configuration_modules` | http_2xx: { prober: http, timeout: 5s, http: '' } | |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 blackbox_exporter_version: 0.18.0
+blackbox_exporter_binary_local_dir: ''
 
 blackbox_exporter_web_listen_address: "0.0.0.0:9115"
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,27 +13,40 @@
     group: blackbox-exp
     createhome: false
 
-- name: download blackbox exporter binary to local folder
-  become: false
-  unarchive:
-    src: "https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_exporter_version }}/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
-    remote_src: true
-    creates: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
-  register: _download_binary
-  until: _download_binary is succeeded
-  retries: 5
-  delay: 2
-  delegate_to: localhost
-  check_mode: false
+- block:
+    - name: download blackbox exporter binary to local folder
+      become: false
+      unarchive:
+        src: "https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_exporter_version }}/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+        dest: "/tmp"
+        remote_src: true
+        creates: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
+      register: _download_binary
+      until: _download_binary is succeeded
+      retries: 5
+      delay: 2
+      delegate_to: localhost
+      check_mode: false
 
-- name: propagate blackbox exporter binary
+    - name: propagate blackbox exporter binary
+      copy:
+        src: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
+        dest: "/usr/local/bin/blackbox_exporter"
+        mode: 0750
+        owner: blackbox-exp
+        group: blackbox-exp
+      notify:
+        - restart blackbox exporter
+  when: blackbox_exporter_binary_local_dir | length == 0
+
+- name: propagate locally distributed blackbox_exporter binary
   copy:
-    src: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/blackbox_exporter"
+    src: "{{ blackbox_exporter_binary_local_dir }}/blackbox_exporter"
     dest: "/usr/local/bin/blackbox_exporter"
     mode: 0750
     owner: blackbox-exp
     group: blackbox-exp
+  when: blackbox_exporter_binary_local_dir | length > 0
   notify:
     - restart blackbox exporter
 


### PR DESCRIPTION
analogous to the prometheus and alertmanager roles, add a blackbox_exporter_binary_local_dir to copy the binary from instead of downloading it from github