### PR TITLE
replaced include with import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
-- include: preflight.yml
+- import_tasks: preflight.yml
   tags:
     - blackbox_exporter_install
     - blackbox_exporter_configure
     - blackbox_exporter_run
 
-- include: install.yml
+- import_tasks: install.yml
   become: true
   tags:
     - blackbox_exporter_install
 
-- include: configure.yml
+- import_tasks: configure.yml
   become: true
   tags:
     - blackbox_exporter_configure


### PR DESCRIPTION
``` 
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg.
```

replaced include with import_tasks because of deprecation warning